### PR TITLE
[FIX] Format C# code before writing it on the AppEnv file

### DIFF
--- a/Anv.Tests/SourceGeneration.cs
+++ b/Anv.Tests/SourceGeneration.cs
@@ -11,7 +11,7 @@ public class SourceGeneration
     {
         Console.WriteLine("test");
 
-        Console.ReadKey();
+        //Console.Read();
 
         var envFile = File.ReadAllText("../../.././env.test.1");
 
@@ -65,7 +65,7 @@ public class SourceGeneration
 
         BuildAnvClass(tree, sb);
 
-        Console.WriteLine(sb.ToString());
+        Console.WriteLine(sb.ToString().FormatCSharpCode());
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class SourceGeneration
     {
         Console.WriteLine("test");
 
-        Console.ReadKey();
+        Console.Read();
 
         var envFile = File.ReadAllText("../../.././env.test.2");
 
@@ -127,7 +127,6 @@ public class SourceGeneration
 
         BuildAnvClass(tree, sb);
 
-        Console.WriteLine(sb.ToString());
+        Console.WriteLine(sb.ToString().FormatCSharpCode());
     }
-
 }

--- a/Anv.Tool/Anv.Tool.csproj
+++ b/Anv.Tool/Anv.Tool.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
   </ItemGroup>
 
 </Project>

--- a/Anv.Tool/Generation.cs
+++ b/Anv.Tool/Generation.cs
@@ -1,10 +1,12 @@
 using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
 
 namespace Anv.Tool;
 
 public static class Generation
 {
-
     public static AnvTree GenerateTree(string env, bool doubleQuoteSeparator = false)
     {
         var tree = new AnvTree()
@@ -31,8 +33,7 @@ public static class Generation
         return tree;
     }
 
-
-    public static void ParseTokens(AnvTree fatherNode, string[] lines, bool useUnderlineSeparator = false, int depth = 0)
+    private static void ParseTokens(AnvTree fatherNode, string[] lines, bool useUnderlineSeparator = false, int depth = 0)
     {
         var token = lines.ElementAtOrDefault(depth);
 
@@ -84,6 +85,19 @@ public static class Generation
         }
 
         sb.AppendLine("}");
+    }
+
+    public static string FormatCSharpCode(this string code)
+    {
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        var workspace = new AdhocWorkspace();
+        var options = workspace.Options;
+
+        var formattedRoot = Formatter.Format(root, workspace, options);
+
+        return formattedRoot.ToFullString();
     }
 }
 

--- a/Anv.Tool/Program.cs
+++ b/Anv.Tool/Program.cs
@@ -1,10 +1,8 @@
 using System.Text;
 using Cocona;
-
 using static Anv.Tool.Generation;
 
 var app = CoconaApp.Create();
-
 
 app.AddCommand("generate", (string output, string envFile = ".env.example", bool doubleQuoteSeparator = false) =>
 {
@@ -18,7 +16,7 @@ app.AddCommand("generate", (string output, string envFile = ".env.example", bool
 
     BuildAnvClass(tree, sb);
 
-    var content = sb.ToString();
+    var content = sb.ToString().FormatCSharpCode();
 
     var path = Path.Join(output, "AppEnv.cs");
 
@@ -26,4 +24,3 @@ app.AddCommand("generate", (string output, string envFile = ".env.example", bool
 });
 
 app.Run();
-


### PR DESCRIPTION
# Code Format

This change fixes the code generation indentation for Anv, where the file AppAnv.cs was created without it. Having a better understanding of the class.
 
## Before

```c#
namespace Anv;
public static partial class AppEnv {
public static partial class SOMETHING {
public static partial class BETTER {
public static readonly AnvEnv CODE_FORMAT = new("SOMETHING__BETTER__CODE_FORMAT");
public static readonly AnvEnv THIS = new ("SOMETHING__BETTER_THIS");
}
}
}
```

## After

```c#
namespace Anv;
public static partial class AppEnv 
{
  public static partial class SOMETHING 
  {
    public static partial class BETTER 
    {
      public static readonly AnvEnv CODE_FORMAT = new("SOMETHING__BETTER__CODE_FORMAT");
      public static readonly AnvEnv THIS = new ("SOMETHING__BETTER_THIS");
    }
  }
}
```